### PR TITLE
minor change(s): change in how oz token standard is imported and upda…

### DIFF
--- a/Build-your-own-cryptocurrency.md
+++ b/Build-your-own-cryptocurrency.md
@@ -44,9 +44,9 @@ In the contract, write the following code:
 
 ```solidity
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.18;
 
-import "https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract LW3Token is ERC20 {
     constructor(string memory _name, string memory _symbol) ERC20(_name, _symbol) {
@@ -58,15 +58,15 @@ contract LW3Token is ERC20 {
 Let's break it down line-by-line and understand what is going on:
 
 ```solidity
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.18;
 ```
 
-This line specifies the compiler version of Solidity to be used. `^0.8.0` means any version greater than `0.8.0`. Usually, you would want to use the latest Solidity compiler version, as a new version usually implies either new features or optimizations.
+This line specifies the compiler version of Solidity to be used. `^0.8.18` means any version greater than `0.8.18`. Usually, you would want to use the latest Solidity compiler version, as a new version usually implies either new features or optimizations.
 
 ---
 
 ```solidity
-import "https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 ```
 
 This line imports the `ERC-20` token standard from [OpenZeppelin](https://openzeppelin.com/) (OZ). OZ is an Ethereum security company. Among other things, OZ develops reference contracts for popular smart contract standards which are thoroughly tested and secure. Whenever implementing a smart contract which needs to comply with a standard, try to find an OZ reference implementation rather than rewriting the entire standard from scratch.


### PR DESCRIPTION
### 1. Minor change to how OZ ERC-20 standard is imported (to make it friendly for hardhat users):

- While using ```"import https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol"```, it works with Remix but Hardhat gives an error as it does not seem to support https imports.

Error Screenshot:
![Screenshot from 2023-04-15 23-30-12](https://user-images.githubusercontent.com/130102996/232245719-dc419ddd-3c51-4eba-a531-0ae77dd7c4ac.png)

- So, with ```"import @openzeppelin/contracts/token/ERC20/ERC20.sol"```, hardhat users just need to locally ```"npm install @openzeppelin/contracts"```.
And now,  ```"npx hardhat compile"``` will run without any issues.

Compilation success screenshot:
![Screenshot from 2023-04-15 23-39-54](https://user-images.githubusercontent.com/130102996/232246255-d01ff5d1-d930-4b18-8cf4-279a2b804605.png)


### 2. Changed solidity version to newer ^0.8.18 in code snippets.