### PR TITLE
changed goerlifaucet.com to sepoliafaucet.com

### DIFF
--- a/Build-your-first-dApp.md
+++ b/Build-your-first-dApp.md
@@ -29,7 +29,7 @@ If you would rather learn from a video, we have a recording available of this tu
 
 2. **Request some Goerli Testnet Ether from a faucet loaded into your Metamask Wallet.**
 
-   - [Faucet link to request funds](https://goerlifaucet.com/)
+   - [Faucet link to request funds](https://sepoliafaucet.com/)
    - [Blog explaining a faucet and how to use one](https://blog.b9lab.com/when-we-first-built-our-faucet-we-deployed-it-on-the-morden-testnet-70bfbf4e317e)
 
 


### PR DESCRIPTION
```GoerliFaucet.com is not working anymore.```

![image](https://github.com/LearnWeb3DAO/Freshman-Track/assets/67726628/89f2fd8e-fdbc-48ab-905e-46920c9c7ab6)

```sepolia testnet working:```

![image](https://github.com/LearnWeb3DAO/Freshman-Track/assets/67726628/8ad88883-1220-4800-bf63-26e869525ccf)
